### PR TITLE
Add network policies for monitoring components

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/norwoodj/helm-docs
+    rev: "v1.11.3"
+    hooks:
+      - id: helm-docs
+        args:
+          - --chart-search-root=./

--- a/README.md
+++ b/README.md
@@ -44,11 +44,13 @@ available config parameters:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
+| `caas.clusterCosts` | bool | `true` | whether the cluster has kubecost installed |
+| `caas.dynatrace` | bool | `true` | whether the cluster has a dynatrace operator installed |
 | `caas.fullnameOverride` | string | `""` |  |
 | `caas.grafana.configmaps` | bool | `false` |  |
 | `caas.nameOverride` | string | `""` |  |
-| `caas.namespaceOverride` | string | `""` |  |
-| `caas.rbac.enabled` | bool | `true` |  |
+| `caas.namespaceOverride` | string | `""` | overrides the default namespace for caas related resources |
+| `caas.rbac.enabled` | bool | `true` | create a namespaces ServiceAccount |
 | `caas.rbac.serviceAccount.create` | bool | `true` |  |
 | `caas.rbac.serviceAccount.name` | string | `"rancher-monitoring"` |  |
 
@@ -284,6 +286,8 @@ available config parameters:
 | `kube-prometheus-stack.prometheus-node-exporter.prometheus.monitor.enabled` | bool | `true` |  |
 | `kube-prometheus-stack.prometheus-node-exporter.rbac.pspEnabled` | bool | `false` |  |
 | `kube-prometheus-stack.prometheus-node-exporter.releaseLabel` | bool | `true` |  |
+| `kube-prometheus-stack.prometheus-node-exporter.service.port` | int | `9796` |  |
+| `kube-prometheus-stack.prometheus-node-exporter.service.targetPort` | int | `9796` |  |
 | `kube-prometheus-stack.prometheus.additionalRulesForClusterRole[0].apiGroups[0]` | string | `""` |  |
 | `kube-prometheus-stack.prometheus.additionalRulesForClusterRole[0].resources[0]` | string | `"configmaps"` |  |
 | `kube-prometheus-stack.prometheus.additionalRulesForClusterRole[0].resources[1]` | string | `"namespaces"` |  |

--- a/templates/np-dynakube.yaml
+++ b/templates/np-dynakube.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.caas.dynatrace }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-from-dynatrace
+  namespace: cattle-monitoring-system
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          field.cattle.io/projectId: dynatrace
+  podSelector:
+    matchLabels:
+      release: rancher-monitoring
+  policyTypes:
+  - Ingress
+{{- end }}

--- a/templates/np-kubecost.yaml
+++ b/templates/np-kubecost.yaml
@@ -1,0 +1,19 @@
+
+{{- if .Values.caas.clusterCosts }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+    name: allow-ingress-from-cluster-costs
+    namespace: cattle-monitoring-system
+spec:
+    ingress:
+    - from:
+        - namespaceSelector:
+                matchLabels:
+                    field.cattle.io/projectId: cluster-costs
+    podSelector:
+        matchLabels:
+            app.kubernetes.io/name: kube-state-metrics
+    policyTypes:
+    - Ingress
+{{- end }}

--- a/templates/np-prometheus-auth.yaml
+++ b/templates/np-prometheus-auth.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-prometheus-auth
+  namespace: cattle-monitoring-system
+spec:
+  ingress:
+  - ports:
+    - port: 9091
+      protocol: TCP
+  podSelector: {}
+  policyTypes:
+  - Ingress
+status: {}

--- a/templates/np-quality-dashboard.yaml
+++ b/templates/np-quality-dashboard.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-grafana-to-prometheus
+  namespace: cattle-monitoring-system
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: caas-quality-dashboard
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes:
+  - Ingress
+status: {}

--- a/values.yaml
+++ b/values.yaml
@@ -3,8 +3,8 @@
 # Declare variables to be passed into your templates.
 
 caas:
-  # create a namespaces ServiceAccount
   rbac:
+    # -- create a namespaces ServiceAccount
     enabled: true
     serviceAccount:
       create: true
@@ -15,11 +15,11 @@ caas:
     configmaps: false
   fullnameOverride: ""
   nameOverride: ""
-  # overrides the default namespace for caas related resources
+  # -- overrides the default namespace for caas related resources
   namespaceOverride: ""
-  # whether the cluster has a dynatrace operator installed
+  # -- whether the cluster has a dynatrace operator installed
   dynatrace: true
-  # whether the cluster has kubecost installed
+  # -- whether the cluster has kubecost installed
   clusterCosts: true
 
 global:

--- a/values.yaml
+++ b/values.yaml
@@ -17,7 +17,11 @@ caas:
   nameOverride: ""
   # overrides the default namespace for caas related resources
   namespaceOverride: ""
-  #
+  # whether the cluster has a dynatrace operator installed
+  dynatrace: true
+  # whether the cluster has kubecost installed
+  clusterCosts: true
+
 global:
   cattle:
     clusterId: local
@@ -352,7 +356,7 @@ kube-prometheus-stack:
 
         {{- end -}}
     alertmanagerSpec:
-      alertmanagerConfigSelector: 
+      alertmanagerConfigSelector:
         matchExpressions:
           - key: release
             operator: In
@@ -655,56 +659,56 @@ kube-prometheus-stack:
         repository: kubeprometheusstack/prometheus-config-reloader
   prometheus:
     additionalRulesForClusterRole:
-    - apiGroups:
-      - ""
-      resources:
-      - configmaps
-      - namespaces
-      - nodes
-      - nodes/metrics
-      - services
-      - endpoints
-      - pods
-      - secrets
-      verbs:
-      - get
-      - list
-      - watch
-    - apiGroups:
-      - networking.k8s.io
-      resources:
-      - ingresses
-      verbs:
-      - get
-      - list
-      - watch
-    - nonResourceURLs:
-      - /metrics
-      - /metrics/cadvisor
-      verbs:
-      - get
-    - apiGroups:
-      - authentication.k8s.io
-      resources:
-      - tokenreviews
-      verbs:
-      - get
-      - list
-      - create
-      - update
-      - delete
-      - watch
-    - apiGroups:
-      - authorization.k8s.io
-      resources:
-      - subjectaccessreviews
-      verbs:
-      - get
-      - list
-      - create
-      - update
-      - delete
-      - watch
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+          - namespaces
+          - nodes
+          - nodes/metrics
+          - services
+          - endpoints
+          - pods
+          - secrets
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - networking.k8s.io
+        resources:
+          - ingresses
+        verbs:
+          - get
+          - list
+          - watch
+      - nonResourceURLs:
+          - /metrics
+          - /metrics/cadvisor
+        verbs:
+          - get
+      - apiGroups:
+          - authentication.k8s.io
+        resources:
+          - tokenreviews
+        verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - watch
+      - apiGroups:
+          - authorization.k8s.io
+        resources:
+          - subjectaccessreviews
+        verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - watch
     enabled: true
     ingress:
       enabled: false
@@ -719,11 +723,11 @@ kube-prometheus-stack:
       additionalScrapeConfigs: []
       containers:
         - args:
-          - --proxy-url=http://127.0.0.1:9090
-          - --listen-address=$(POD_IP):9091
-          - --filter-reader-labels=prometheus
-          - --filter-reader-labels=prometheus_replica
-          - --log.debug=true
+            - --proxy-url=http://127.0.0.1:9090
+            - --listen-address=$(POD_IP):9091
+            - --filter-reader-labels=prometheus
+            - --filter-reader-labels=prometheus_replica
+            - --log.debug=true
           command:
             - prometheus-auth
           env:
@@ -734,9 +738,9 @@ kube-prometheus-stack:
           image: mtr.devops.telekom.de/caas/prometheus-auth:0.5.1
           name: prometheus-agent
           ports:
-          - containerPort: 9091
-            name: http-auth
-            protocol: TCP
+            - containerPort: 9091
+              name: http-auth
+              protocol: TCP
           resources:
             limits:
               cpu: 500m
@@ -896,35 +900,35 @@ k3sServer:
       insecureSkipVerify: true
     rbac:
       additionalRules:
-      - nonResourceURLs: ["/metrics/cadvisor"]
-        verbs: ["get"]
-      - apiGroups: [""]
-        resources: ["nodes/metrics"]
-        verbs: ["get"]
+        - nonResourceURLs: ["/metrics/cadvisor"]
+          verbs: ["get"]
+        - apiGroups: [""]
+          resources: ["nodes/metrics"]
+          verbs: ["get"]
     tolerations:
-    - effect: "NoExecute"
-      operator: "Exists"
-    - effect: "NoSchedule"
-      operator: "Exists"
+      - effect: "NoExecute"
+        operator: "Exists"
+      - effect: "NoSchedule"
+        operator: "Exists"
   serviceMonitor:
     endpoints:
-    - port: metrics
-      honorLabels: true
-      relabelings:
-      - sourceLabels: [__metrics_path__]
-        targetLabel: metrics_path
-    - port: metrics
-      path: /metrics/cadvisor
-      honorLabels: true
-      relabelings:
-      - sourceLabels: [__metrics_path__]
-        targetLabel: metrics_path
-    - port: metrics
-      path: /metrics/probes
-      honorLabels: true
-      relabelings:
-      - sourceLabels: [__metrics_path__]
-        targetLabel: metrics_path
+      - port: metrics
+        honorLabels: true
+        relabelings:
+          - sourceLabels: [__metrics_path__]
+            targetLabel: metrics_path
+      - port: metrics
+        path: /metrics/cadvisor
+        honorLabels: true
+        relabelings:
+          - sourceLabels: [__metrics_path__]
+            targetLabel: metrics_path
+      - port: metrics
+        path: /metrics/probes
+        honorLabels: true
+        relabelings:
+          - sourceLabels: [__metrics_path__]
+            targetLabel: metrics_path
 
 rkeControllerManager:
   enabled: false
@@ -940,19 +944,19 @@ rkeControllerManager:
     nodeSelector:
       node-role.kubernetes.io/controlplane: "true"
     tolerations:
-    - effect: "NoExecute"
-      operator: "Exists"
-    - effect: "NoSchedule"
-      operator: "Exists"
+      - effect: "NoExecute"
+        operator: "Exists"
+      - effect: "NoSchedule"
+        operator: "Exists"
   kubeVersionOverrides:
-  - constraint: "< 1.22"
-    values:
-      metricsPort: 10252 # default to insecure port in k8s < 1.22
-      clients:
-        https:
-          enabled: false
-          insecureSkipVerify: false
-          useServiceAccountCredentials: false
+    - constraint: "< 1.22"
+      values:
+        metricsPort: 10252 # default to insecure port in k8s < 1.22
+        clients:
+          https:
+            enabled: false
+            insecureSkipVerify: false
+            useServiceAccountCredentials: false
 
 rkeScheduler:
   enabled: false
@@ -968,19 +972,19 @@ rkeScheduler:
     nodeSelector:
       node-role.kubernetes.io/controlplane: "true"
     tolerations:
-    - effect: "NoExecute"
-      operator: "Exists"
-    - effect: "NoSchedule"
-      operator: "Exists"
+      - effect: "NoExecute"
+        operator: "Exists"
+      - effect: "NoSchedule"
+        operator: "Exists"
   kubeVersionOverrides:
-  - constraint: "< 1.23"
-    values:
-      metricsPort: 10251 # default to insecure port in k8s < 1.23
-      clients:
-        https:
-          enabled: false
-          insecureSkipVerify: false
-          useServiceAccountCredentials: false
+    - constraint: "< 1.23"
+      values:
+        metricsPort: 10251 # default to insecure port in k8s < 1.23
+        clients:
+          https:
+            enabled: false
+            insecureSkipVerify: false
+            useServiceAccountCredentials: false
 
 rkeProxy:
   enabled: false
@@ -990,10 +994,10 @@ rkeProxy:
     port: 10013
     useLocalhost: true
     tolerations:
-    - effect: "NoExecute"
-      operator: "Exists"
-    - effect: "NoSchedule"
-      operator: "Exists"
+      - effect: "NoExecute"
+        operator: "Exists"
+      - effect: "NoSchedule"
+        operator: "Exists"
 
 rkeEtcd:
   enabled: false
@@ -1014,10 +1018,10 @@ rkeEtcd:
     nodeSelector:
       node-role.kubernetes.io/etcd: "true"
     tolerations:
-    - effect: "NoExecute"
-      operator: "Exists"
-    - effect: "NoSchedule"
-      operator: "Exists"
+      - effect: "NoExecute"
+        operator: "Exists"
+      - effect: "NoSchedule"
+        operator: "Exists"
 
 rkeIngressNginx:
   enabled: false


### PR DESCRIPTION
## Motivation

This pull request adds network policies for the monitoring components in the cattle-monitoring-system namespace. 

## Changes

Network policies to allow: 

- ingress from the caas-quality-dashboard namespace to the prometheus pod, 
- ingress from the dynatrace namespace to the rancher-monitoring pod (if the cluster has dynatrace installed)
- ingress from the cluster-costs namespace to the kube-state-metrics pod (if the cluster has kubecost installed).

Also added some additional values to the values.yaml to accomodate the changes.

Finally, I've added a pre-commit to always generate the helm docs :) Thanks for including the template.

## Tests done

- helm template create the network policies