### PR TITLE
Fix honorLabels for kube-state-metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ available config parameters:
 | `kube-prometheus-stack.kube-state-metrics.image.repository` | string | `"kubeprometheusstack/kube-state-metrics"` |  |
 | `kube-prometheus-stack.kube-state-metrics.image.tag` | string | `"v2.10.0"` |  |
 | `kube-prometheus-stack.kube-state-metrics.prometheus.monitor.enabled` | bool | `true` |  |
-| `kube-prometheus-stack.kube-state-metrics.prometheus.monitor.honorLabels` | bool | `false` |  |
+| `kube-prometheus-stack.kube-state-metrics.prometheus.monitor.honorLabels` | bool | `true` |  |
 | `kube-prometheus-stack.kube-state-metrics.rbac.create` | bool | `true` |  |
 | `kube-prometheus-stack.kube-state-metrics.releaseLabel` | bool | `true` |  |
 | `kube-prometheus-stack.kube-state-metrics.selfMonitor.enabled` | bool | `true` |  |

--- a/values.yaml
+++ b/values.yaml
@@ -610,7 +610,7 @@ kube-prometheus-stack:
     prometheus:
       monitor:
         enabled: true
-        honorLabels: false
+        honorLabels: true
     selfMonitor:
       enabled: true
   nodeExporter:


### PR DESCRIPTION
This pull request fixes the `honorLabels` configuration parameter for `kube-state-metrics` in the `kube-prometheus-stack` chart. The parameter was incorrectly set to `false` and has been updated to `true` to ensure that labels are honored when scraping metrics from the kube-state-metrics pod  to ensure `namespace` labels matches the namespace of the pod, and not just `cattle-monitoring-system` (the release namespace).