### PR TITLE
Docs/rework comp matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ A fork of the official [rancher cluster monitoring](https://github.com/rancher/c
 
 If you're comming from an existing rancher-monitoring installation:
 
-- you must first update the prometheus-operator CRDs separately. This chart only includes the kube-prometheus-stack *without* the CRDs.
-- you should additionally uninstall the rancher-monitoring chart before installing this one.
-- do not delete the rancher-monitoring-crds chart, as this will delete all custom resources already created (or back them up first and recreate them).
+* you must first update the prometheus-operator CRDs separately. This chart only includes the kube-prometheus-stack *without* the CRDs.
+* you should additionally uninstall the rancher-monitoring chart before installing this one.
+* do not delete the rancher-monitoring-crds chart, as this will delete all custom resources already created (or back them up first and recreate them).
 
 To install run the following command:
 
@@ -34,7 +34,7 @@ helm -n cattle-monitoring-system upgrade -i rancher-monitoring .
 
 The following table shows the compatibility between the CaaS Cluster Monitoring chart and the CaaS Project Monitoring versions:
 
-| CaaS Cluster Monitoring | compatible with CaaS Project Monitoring | deployed kube-prometheus-stack |
+| CaaS Cluster Monitoring | compatible with CaaS Project Monitoring | used kube-prometheus-stack     |
 | ----------------------- | --------------------------------------- | ------------------------------ |
 | < 0.0.6                 | < 1.0.0                                 | 51.0.3                         |
 | 0.0.6 < x < 1.0.0       | 1.0.0 <= y < 1.4.0                      | 58.4.0                         |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # caas-cluster-monitoring
 
-A fork of the official [rancher cluster monitoring](https://github.com/rancher/charts/tree/dev-v2.9/charts/rancher-monitoring) with more up-to-date prometheus-operator CRDs and features and [prometheus-auth](https://github.com/caas-team/prometheus-auth) to enable multi-tenancy for the proemtheus metrics.
+A fork of the official [rancher cluster monitoring](https://github.com/rancher/charts/tree/dev-v2.9/charts/rancher-monitoring)
+with more up-to-date prometheus-operator CRDs, features and a maintained fork of rancher's [prometheus-auth](https://github.com/caas-team/prometheus-auth)
+to enable multi-tenancy for the prometheus  metrics.
 
 ## Maintainers
 
@@ -14,15 +16,13 @@ A fork of the official [rancher cluster monitoring](https://github.com/rancher/c
 * <https://github.com/caas-team/caas-cluster-monitoring>
 * <https://github.com/prometheus-community/helm-charts>
 
-A fork of the official [rancher cluster monitoring](https://github.com/rancher/charts/tree/dev-v2.9/charts/rancher-monitoring) with more up-to-date prometheus-operator CRDs and features and [prometheus-auth](https://github.com/caas-team/prometheus-auth) to enable multi-tenancy for the proemtheus metrics.
-
 ## Installation
 
-If you're comming from an existing rancher-monitoring installation:
+If you're coming from an existing rancher-monitoring installation:
 
 * you must first update the prometheus-operator CRDs separately. This chart only includes the kube-prometheus-stack *without* the CRDs.
 * you should additionally uninstall the rancher-monitoring chart before installing this one.
-* do not delete the rancher-monitoring-crds chart, as this will delete all custom resources already created (or back them up first and recreate them).
+* do not delete the `rancher-monitoring-crds` chart, as this will delete all custom resources already created (or back them up first and recreate them).
 
 To install run the following command:
 

--- a/README.md
+++ b/README.md
@@ -1,49 +1,52 @@
-# CaaS Cluster Monitoring
+# caas-cluster-monitoring
+
+A fork of the official [rancher cluster monitoring](https://github.com/rancher/charts/tree/dev-v2.9/charts/rancher-monitoring) with more up-to-date prometheus-operator CRDs and features and [prometheus-auth](https://github.com/caas-team/prometheus-auth) to enable multi-tenancy for the proemtheus metrics.
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| eumel8 | <f.kloeker@telekom.de> | <https://www.telekom.com> |
+| puffitos | <bruno.bressi@telekom.de> | <https://www.telekom.com> |
+
+## Source Code
+
+* <https://github.com/caas-team/caas-cluster-monitoring>
+* <https://github.com/prometheus-community/helm-charts>
 
 ## Installation
 
-With de-installation of the origin Rancher Monitoring and keept resources
+If you're comming from an existing rancher-monitoring installation:
 
-```bash
-helm -n cattle-monitoring-system delete rancher-monitoring
-kubectl -n cattle-monitoring-system delete secret alertmanager-rancher-monitoring-alertmanager
-```
+- you must first update the prometheus-operator CRDs separately. This chart only includes the kube-prometheus-stack *without* the CRDs.
+- you should additionally uninstall the rancher-monitoring chart before installing this one.
+- do not delete the rancher-monitoring-crds chart, as this will delete all custom resources already created (or back them up first and recreate them).
 
-Deleting of rancher-monitoring-crd would delete also all corresponding Custom Resources. We delete only the Helm release secrets and keep CRDs into the cluster
-
-```bash
-kubectl -n cattle-monitoring-system get secrets -o name --no-headers | grep sh.helm.release.v1.rancher-monitoring-crd | xargs kubectl -n cattle-monitoring-system  delete $1
-```
-
-Nevertheless we need to upgrade CRDs manually because there is no logic to do this in Helm:
-
-```bash
-cd charts
-tar xvfz kube-prometheus-stack-51.0.3.tgz
-cd kube-prometheus-stack/charts/crds
-kubectl apply -f crds/ --server-side --force-conflicts
-```
-
-To decouple CRDs from this chart (you may have installed CRDs from another chart or logic), feature is disabled:
-
-```yaml
-kube-prometheus-stack:
-  crds:
-    enabled: false
-```
-
-Upgrade to the kube-prometheus-stack:
+To install run the following command:
 
 ```bash
 helm -n cattle-monitoring-system upgrade -i rancher-monitoring .
 ```
 
-available config parameters:
+## Compatibility matrix
+
+The following table shows the compatibility between the CaaS Cluster Monitoring chart and the CaaS Project Monitoring versions:
+
+| CaaS Cluster Monitoring | compatible with CaaS Project Monitoring | deployed kube-prometheus-stack |
+| ----------------------- | --------------------------------------- | ------------------------------ |
+| < 0.0.6                 | < 1.0.0                                 | 51.0.3                         |
+| 0.0.6 < x < 1.0.0       | 1.0.0 <= y < 1.4.0                      | 58.4.0                         |
+
+where `x` is the CaaS Cluster Monitoring Version and `y` is the CaaS Project Monitoring Version.
+
+## Configuration
+
+The installation can be configured using the various parameters defined in the `values.yaml` file. The following tables list the configurable parameters of the CaaS Cluster Monitoring chart and their default values.
 
 ### caas
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
+| --------- | ---- | ------- | ----------- |
 | `caas.clusterCosts` | bool | `true` | whether the cluster has kubecost installed |
 | `caas.defaultEgress` | bool | `false` | whether the cluster needs defaultEgress  installed |
 | `caas.dynatrace` | bool | `true` | whether the cluster has a dynatrace operator installed |
@@ -59,7 +62,7 @@ available config parameters:
 ### global
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
+| --------- | ---- | ------- | ----------- |
 | `global.cattle.clusterId` | string | `"local"` |  |
 | `global.cattle.clusterName` | string | `"local"` |  |
 | `global.cattle.systemDefaultRegistry` | string | `"mtr.devops.telekom.de"` |  |
@@ -73,7 +76,7 @@ available config parameters:
 ### kube-prometheus-stack
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
+| --------- | ---- | ------- | ----------- |
 | `kube-prometheus-stack.alertmanager.alertmanagerSpec.alertmanagerConfigNamespaceSelector` | object | `{}` |  |
 | `kube-prometheus-stack.alertmanager.alertmanagerSpec.alertmanagerConfigSelector.matchExpressions[0].key` | string | `"release"` |  |
 | `kube-prometheus-stack.alertmanager.alertmanagerSpec.alertmanagerConfigSelector.matchExpressions[0].operator` | string | `"In"` |  |
@@ -462,7 +465,7 @@ available config parameters:
 ### rkeControllerManager
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
+| --------- | ---- | ------- | ----------- |
 | `rkeControllerManager.clients.https.enabled` | bool | `true` |  |
 | `rkeControllerManager.clients.https.insecureSkipVerify` | bool | `true` |  |
 | `rkeControllerManager.clients.https.useServiceAccountCredentials` | bool | `true` |  |
@@ -488,7 +491,7 @@ available config parameters:
 ### rkeEtcd
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
+| --------- | ---- | ------- | ----------- |
 | `rkeEtcd.clients.https.authenticationMethod.authorization.enabled` | bool | `false` |  |
 | `rkeEtcd.clients.https.authenticationMethod.bearerTokenFile.enabled` | bool | `false` |  |
 | `rkeEtcd.clients.https.authenticationMethod.bearerTokenSecret.enabled` | bool | `false` |  |
@@ -514,7 +517,7 @@ available config parameters:
 ### rkeIngressNginx
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
+| --------- | ---- | ------- | ----------- |
 | `rkeIngressNginx.clients.nodeSelector."node-role.kubernetes.io/worker"` | string | `"true"` |  |
 | `rkeIngressNginx.clients.port` | int | `10015` |  |
 | `rkeIngressNginx.clients.tolerations[0].effect` | string | `"NoExecute"` |  |
@@ -529,7 +532,7 @@ available config parameters:
 ### rkeProxy
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
+| --------- | ---- | ------- | ----------- |
 | `rkeProxy.clients.port` | int | `10013` |  |
 | `rkeProxy.clients.tolerations[0].effect` | string | `"NoExecute"` |  |
 | `rkeProxy.clients.tolerations[0].operator` | string | `"Exists"` |  |
@@ -546,7 +549,7 @@ available config parameters:
 ### rkeScheduler
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
+| --------- | ---- | ------- | ----------- |
 | `rkeScheduler.clients.https.authenticationMethod.authorization.enabled` | bool | `false` |  |
 | `rkeScheduler.clients.https.authenticationMethod.bearerTokenFile.enabled` | bool | `false` |  |
 | `rkeScheduler.clients.https.authenticationMethod.bearerTokenSecret.enabled` | bool | `false` |  |
@@ -575,7 +578,7 @@ available config parameters:
 ### hardenedKubelet
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
+| --------- | ---- | ------- | ----------- |
 | `hardenedKubelet.clients.https.authenticationMethod.authorization.enabled` | bool | `false` |  |
 | `hardenedKubelet.clients.https.authenticationMethod.bearerTokenFile.enabled` | bool | `false` |  |
 | `hardenedKubelet.clients.https.authenticationMethod.bearerTokenSecret.enabled` | bool | `false` |  |
@@ -620,5 +623,3 @@ available config parameters:
 | `hardenedKubelet.serviceMonitor.endpoints[2].port` | string | `"metrics"` |  |
 | `hardenedKubelet.serviceMonitor.endpoints[2].relabelings[0].sourceLabels[0]` | string | `"__metrics_path__"` |  |
 | `hardenedKubelet.serviceMonitor.endpoints[2].relabelings[0].targetLabel` | string | `"metrics_path"` |  |
-
-Autogenerated from chart metadata using [helm-docs v1.11.3](https://github.com/norwoodj/helm-docs/releases/v1.11.3)

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -12,9 +12,9 @@ A fork of the official [rancher cluster monitoring](https://github.com/rancher/c
 
 If you're comming from an existing rancher-monitoring installation:
 
-- you must first update the prometheus-operator CRDs separately. This chart only includes the kube-prometheus-stack *without* the CRDs.
-- you should additionally uninstall the rancher-monitoring chart before installing this one.
-- do not delete the rancher-monitoring-crds chart, as this will delete all custom resources already created (or back them up first and recreate them).
+* you must first update the prometheus-operator CRDs separately. This chart only includes the kube-prometheus-stack *without* the CRDs.
+* you should additionally uninstall the rancher-monitoring chart before installing this one.
+* do not delete the rancher-monitoring-crds chart, as this will delete all custom resources already created (or back them up first and recreate them).
 
 To install run the following command:
 
@@ -26,7 +26,7 @@ helm -n cattle-monitoring-system upgrade -i rancher-monitoring .
 
 The following table shows the compatibility between the CaaS Cluster Monitoring chart and the CaaS Project Monitoring versions:
 
-| CaaS Cluster Monitoring | compatible with CaaS Project Monitoring | deployed kube-prometheus-stack |
+| CaaS Cluster Monitoring | compatible with CaaS Project Monitoring | used kube-prometheus-stack     |
 | ----------------------- | --------------------------------------- | ------------------------------ |
 | < 0.0.6                 | < 1.0.0                                 | 51.0.3                         |
 | 0.0.6 < x < 1.0.0       | 1.0.0 <= y < 1.4.0                      | 58.4.0                         |

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -1,20 +1,20 @@
 {{ template "chart.header" . }}
 
-A fork of the official [rancher cluster monitoring](https://github.com/rancher/charts/tree/dev-v2.9/charts/rancher-monitoring) with more up-to-date prometheus-operator CRDs and features and [prometheus-auth](https://github.com/caas-team/prometheus-auth) to enable multi-tenancy for the proemtheus metrics.
+A fork of the official [rancher cluster monitoring](https://github.com/rancher/charts/tree/dev-v2.9/charts/rancher-monitoring) 
+with more up-to-date prometheus-operator CRDs, features and a maintained fork of rancher's [prometheus-auth](https://github.com/caas-team/prometheus-auth) 
+to enable multi-tenancy for the prometheus  metrics.
 
 {{ template "chart.maintainersSection" . }}
 
 {{ template "chart.sourcesSection" . }}
 
-A fork of the official [rancher cluster monitoring](https://github.com/rancher/charts/tree/dev-v2.9/charts/rancher-monitoring) with more up-to-date prometheus-operator CRDs and features and [prometheus-auth](https://github.com/caas-team/prometheus-auth) to enable multi-tenancy for the proemtheus metrics.
-
 ## Installation
 
-If you're comming from an existing rancher-monitoring installation:
+If you're coming from an existing rancher-monitoring installation:
 
 * you must first update the prometheus-operator CRDs separately. This chart only includes the kube-prometheus-stack *without* the CRDs.
 * you should additionally uninstall the rancher-monitoring chart before installing this one.
-* do not delete the rancher-monitoring-crds chart, as this will delete all custom resources already created (or back them up first and recreate them).
+* do not delete the `rancher-monitoring-crds` chart, as this will delete all custom resources already created (or back them up first and recreate them).
 
 To install run the following command:
 

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -1,51 +1,45 @@
-# CaaS Cluster Monitoring
+{{ template "chart.header" . }}
+
+A fork of the official [rancher cluster monitoring](https://github.com/rancher/charts/tree/dev-v2.9/charts/rancher-monitoring) with more up-to-date prometheus-operator CRDs and features and [prometheus-auth](https://github.com/caas-team/prometheus-auth) to enable multi-tenancy for the proemtheus metrics.
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
 
 ## Installation
 
-With de-installation of the origin Rancher Monitoring and keept resources
+If you're comming from an existing rancher-monitoring installation:
 
+- you must first update the prometheus-operator CRDs separately. This chart only includes the kube-prometheus-stack *without* the CRDs.
+- you should additionally uninstall the rancher-monitoring chart before installing this one.
+- do not delete the rancher-monitoring-crds chart, as this will delete all custom resources already created (or back them up first and recreate them).
 
-```bash
-helm -n cattle-monitoring-system delete rancher-monitoring
-kubectl -n cattle-monitoring-system delete secret alertmanager-rancher-monitoring-alertmanager
-```
-
-Deleting of rancher-monitoring-crd would delete also all corresponding Custom Resources. We delete only the Helm release secrets and keep CRDs into the cluster
-
-```bash
-kubectl -n cattle-monitoring-system get secrets -o name --no-headers | grep sh.helm.release.v1.rancher-monitoring-crd | xargs kubectl -n cattle-monitoring-system  delete $1
-```
-
-Nevertheless we need to upgrade CRDs manually because there is no logic to do this in Helm:
-
-```bash
-cd charts
-tar xvfz kube-prometheus-stack-51.0.3.tgz
-cd kube-prometheus-stack/charts/crds
-kubectl apply -f crds/ --server-side --force-conflicts 
-```
-
-To decouple CRDs from this chart (you may have installed CRDs from another chart or logic), feature is disabled:
-
-```yaml
-kube-prometheus-stack:
-  crds:
-    enabled: false
-```
-
-Upgrade to the kube-prometheus-stack:
+To install run the following command:
 
 ```bash
 helm -n cattle-monitoring-system upgrade -i rancher-monitoring .
 ```
 
-available config parameters:
+## Compatibility matrix
 
+The following table shows the compatibility between the CaaS Cluster Monitoring chart and the CaaS Project Monitoring versions:
+
+| CaaS Cluster Monitoring | compatible with CaaS Project Monitoring | deployed kube-prometheus-stack |
+| ----------------------- | --------------------------------------- | ------------------------------ |
+| < 0.0.6                 | < 1.0.0                                 | 51.0.3                         |
+| 0.0.6 < x < 1.0.0       | 1.0.0 <= y < 1.4.0                      | 58.4.0                         |
+
+where `x` is the CaaS Cluster Monitoring Version and `y` is the CaaS Project Monitoring Version.
+
+
+## Configuration
+
+The installation can be configured using the various parameters defined in the `values.yaml` file. The following tables list the configurable parameters of the CaaS Cluster Monitoring chart and their default values.
 
 ### caas
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
+| --------- | ---- | ------- | ----------- |
 {{- range .Values }}
   {{- if (contains "caas" .Key) }}
 | `{{ .Key }}` | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
@@ -55,7 +49,7 @@ available config parameters:
 ### global
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
+| --------- | ---- | ------- | ----------- |
 {{- range .Values }}
   {{- if (contains "global" .Key) }}
 | `{{ .Key }}` | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
@@ -65,7 +59,7 @@ available config parameters:
 ### kube-prometheus-stack
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
+| --------- | ---- | ------- | ----------- |
 {{- range .Values }}
   {{- if (contains "kube-prometheus-stack" .Key) }}
 | `{{ .Key }}` | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
@@ -75,7 +69,7 @@ available config parameters:
 ### rkeControllerManager
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
+| --------- | ---- | ------- | ----------- |
 {{- range .Values }}
   {{- if (contains "rkeControllerManager" .Key) }}
 | `{{ .Key }}` | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
@@ -85,7 +79,7 @@ available config parameters:
 ### rkeEtcd
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
+| --------- | ---- | ------- | ----------- |
 {{- range .Values }}
   {{- if (contains "rkeEtcd" .Key) }}
 | `{{ .Key }}` | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
@@ -95,7 +89,7 @@ available config parameters:
 ### rkeIngressNginx
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
+| --------- | ---- | ------- | ----------- |
 {{- range .Values }}
   {{- if (contains "rkeIngressNginx" .Key) }}
 | `{{ .Key }}` | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
@@ -105,7 +99,7 @@ available config parameters:
 ### rkeProxy
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
+| --------- | ---- | ------- | ----------- |
 {{- range .Values }}
   {{- if (contains "rkeProxy" .Key) }}
 | `{{ .Key }}` | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
@@ -115,7 +109,7 @@ available config parameters:
 ### rkeScheduler
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
+| --------- | ---- | ------- | ----------- |
 {{- range .Values }}
   {{- if (contains "rkeScheduler" .Key) }}
 | `{{ .Key }}` | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
@@ -125,11 +119,9 @@ available config parameters:
 ### hardenedKubelet
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
+| --------- | ---- | ------- | ----------- |
 {{- range .Values }}
   {{- if (contains "hardenedKubelet" .Key) }}
 | `{{ .Key }}` | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
   {{- end }}
 {{- end }}
-
-Autogenerated from chart metadata using [helm-docs v1.11.3](https://github.com/norwoodj/helm-docs/releases/v1.11.3)


### PR DESCRIPTION
## Motivation

A compatibility matrix allows users of this chart better understand which version is compatible with the counterpart helm chart (caas-project-monitoring), This matrix is a part of the deprecation of the monitoring.cattle.io API group, which will be removed with the 1.0.0 version and the caas project monitoring v1.4.0 version.

The README was kind of old and I wanted to just sum up everything in a couple of sentences, to make the message more clear. This a fork of the rancher chart, it offers this and that and if you're coming from rancher do a,b and c.

## Additional details

See https://github.com/caas-team/caas-project-monitoring/pull/46

Version 1.0.0 of this chart will include:

- the latest prometheus crds
- new prom auth, which removes the monitoring.cattle.io
- non-deprecated grafana dashboards
- (hopefully) reworked & fixed grafana dashboards