### PR TITLE
Feat/granular dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,14 @@ The installation can be configured using the various parameters defined in the `
 | `caas.defaultEgress` | bool | `false` | whether the cluster needs defaultEgress  installed |
 | `caas.dynatrace` | bool | `true` | whether the cluster has a dynatrace operator installed |
 | `caas.fullnameOverride` | string | `""` |  |
-| `caas.grafana.configmaps` | bool | `false` |  |
+| `caas.grafana.dashboards.nginxIngress` | bool | `true` | whether to deploy the nginx ingress controller dashboard |
+| `caas.grafana.dashboards.rancherCluster` | bool | `true` | whether to deploy the rancher cluster dashboards |
+| `caas.grafana.dashboards.rancherHome` | bool | `true` | whether to deploy the rancher home dashboard |
+| `caas.grafana.dashboards.rancherK8sComponents` | bool | `true` | whether to deploy the rancher k8s components dashboard |
+| `caas.grafana.dashboards.rancherNodes` | bool | `true` | whether to deploy the rancher nodes dashboard |
+| `caas.grafana.dashboards.rancherPerformance` | bool | `true` | whether to deploy the rancher performance dashboard |
+| `caas.grafana.dashboards.rancherPods` | bool | `true` | whether to deploy the rancher pods dashboard |
+| `caas.grafana.dashboards.rancherWorkloads` | bool | `true` | whether to deploy the rancher workloads dashboard |
 | `caas.nameOverride` | string | `""` |  |
 | `caas.namespaceOverride` | string | `""` | overrides the default namespace for caas related resources |
 | `caas.prometheusAuth` | bool | `true` | whether the cluster has Prometheus-Auth  installed |

--- a/templates/grafana-dashboards.yaml
+++ b/templates/grafana-dashboards.yaml
@@ -1,9 +1,88 @@
 ---
+{{ if .Values.caas.grafana.dashboards.nginxIngress }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: rancher-monitoring-dashboards
+  name: dashboards-ingress-nginx
   labels:
     grafana_dashboard: "1"
 data:
-{{ (.Files.Glob "files/**").AsConfig | indent 2 }}
+{{ (.Files.Glob "files/ingress-nginx/*").AsConfig | indent 2 }}
+{{ end }}
+---
+{{ if .Values.caas.grafana.dashboards.rancherCluster }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboards-rancher-cluster
+  labels:
+    grafana_dashboard: "1"
+data:
+{{ (.Files.Glob "files/rancher/cluster/*").AsConfig | indent 2 }}
+{{ end }}
+---
+{{ if .Values.caas.grafana.dashboards.rancherHome }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboards-rancher-home
+  labels:
+    grafana_dashboard: "1"
+data:
+{{ (.Files.Glob "files/rancher/home/*").AsConfig | indent 2 }}
+{{ end }}
+---
+{{ if .Values.caas.grafana.dashboards.rancherK8sComponents }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboards-rancher-k8s-components
+  labels:
+    grafana_dashboard: "1"
+data:
+{{ (.Files.Glob "files/rancher/k8s/*").AsConfig | indent 2 }}
+{{ end }}
+---
+{{ if .Values.caas.grafana.dashboards.rancherNodes }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboards-rancher-nodes
+  labels:
+    grafana_dashboard: "1"
+data:
+{{ (.Files.Glob "files/rancher/nodes/*").AsConfig | indent 2 }}
+{{ end }}
+---
+{{ if .Values.caas.grafana.dashboards.rancherPerformance }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboards-rancher-performance
+  labels:
+    grafana_dashboard: "1"
+data:
+{{ (.Files.Glob "files/rancher/performance/*").AsConfig | indent 2 }}
+{{ end }}
+---
+{{ if .Values.caas.grafana.dashboards.rancherPods }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboards-rancher-pods
+  labels:
+    grafana_dashboard: "1"
+data:
+{{ (.Files.Glob "files/rancher/pods/*").AsConfig | indent 2 }}
+{{ end }}
+---
+{{ if .Values.caas.grafana.dashboards.rancherWorkloads }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboards-rancher-workloads
+  labels:
+    grafana_dashboard: "1"
+data:
+{{ (.Files.Glob "files/rancher/workloads/*").AsConfig | indent 2 }}
+{{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -10,10 +10,6 @@ caas:
   # -- whether the cluster has a dynatrace operator installed
   dynatrace: true
   fullnameOverride: ""
-  # deploy additional nginx.conf and dashboard for Grafana, mostly covered from Rancher
-  # beware of the defaultDashboardsEnabled in kube-prometheus-stack
-  grafana:
-    configmaps: false
   nameOverride: ""
   # -- overrides the default namespace for caas related resources
   namespaceOverride: ""
@@ -25,7 +21,24 @@ caas:
     serviceAccount:
       create: true
       name: rancher-monitoring
-
+  grafana:
+    dashboards:
+      # -- whether to deploy the nginx ingress controller dashboard
+      nginxIngress: true
+      # -- whether to deploy the rancher cluster dashboards
+      rancherCluster: true
+      # -- whether to deploy the rancher home dashboard
+      rancherHome: true
+      # -- whether to deploy the rancher k8s components dashboard
+      rancherK8sComponents: true
+      # -- whether to deploy the rancher nodes dashboard
+      rancherNodes: true
+      # -- whether to deploy the rancher performance dashboard
+      rancherPerformance: true
+      # -- whether to deploy the rancher pods dashboard
+      rancherPods: true
+      # -- whether to deploy the rancher workloads dashboard
+      rancherWorkloads: true
 global:
   cattle:
     clusterId: local


### PR DESCRIPTION
## Motivation

Implements https://github.com/caas-team/caas-cluster-monitoring/issues/25

Not all dashboards are always needed; for example, a cluster may not have longhorn installed or the performance dashboards make no sense in a downstream cluster, as noted in the issue.

## Changes

- Split up the configmap dashboard file into multiple files
- Added value toggles to activate/deactivate dashboards

## Tests done

### All active
Deployed a version with the standard values, all dashboards are present again:

![image](https://github.com/user-attachments/assets/cce7877d-a2c0-4408-92e0-0432941b215a)

I'll do another test with the performance dashboards deactivated (and all others as well) to see how helm and our grafana reacts.

### Rancher Performance deactivated

Changes the values to:

```yaml
caas:
  grafana:
    dashboards:
      rancherPerformance: false
```

The configmap was removed and grafana sucessfully refreshed the dashbhoards. No more rancher perfomance:

![image](https://github.com/user-attachments/assets/09d47556-4163-4e83-afeb-2674eb71b808)

### All rancher dashboards gone

Updated the values to:

```yaml
caas:
  grafana:
    dashboards:
      nginxIngress: false
      rancherCluster: false
      rancherHome: false
      rancherK8sComponents: false
      rancherNodes: false
      rancherPerformance: false
      rancherPods: false
      rancherWorkloads: false
      longhorn: false
```

and, as expected, the dashboards were also removed from grafana:

![image](https://github.com/user-attachments/assets/a9c16db1-2154-4e57-85a5-52575aaca07e)
