### PR TITLE
Bumped chart version to 0.0.14

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
   catalog.cattle.io/display-name: CaaS Cluster Monitoring V3
 name: caas-cluster-monitoring
 description: A Helm chart for Rancher Cluster Monitoring V3
-version: "0.0.14-rc10"
+version: "0.0.14"
 appVersion: "58.4.0"
 icon: https://raw.githubusercontent.com/caas-team/caas-project-monitoring/main/logo.png
 keywords:


### PR DESCRIPTION
## Motivation

Update the project version to 0.0.14 to prepare for release.

## Tests done

The release has been tested through every single PR in a CaaS development cluster. Since this mostly affects dashboards, it shouldn't have any unexpected side effects.

