### PR TITLE
Chore/bump 68.1.1

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 58.4.0
+  version: 68.1.1
 - name: rkeEtcd
   repository: file://./charts/rkeEtcd
   version: 0.2.1
@@ -20,5 +20,5 @@ dependencies:
 - name: hardenedKubelet
   repository: file://./charts/hardenedKubelet
   version: 0.2.1
-digest: sha256:4635b6b3576ecd6ca7b366b93d47acf8a85efa384fefecfed2542732963c7a42
-generated: "2024-06-19T12:03:12.573586664+02:00"
+digest: sha256:961acbe7257c48de7c8b8dd2e9b90deb51ab031f28c13696aecb1a64ca4d44ce
+generated: "2025-01-22T19:07:24.450831813+01:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,13 +4,13 @@ annotations:
 name: caas-cluster-monitoring
 description: A Helm chart for Rancher Cluster Monitoring V3
 version: "0.0.14"
-appVersion: "58.4.0"
+appVersion: "68.1.1"
 icon: https://raw.githubusercontent.com/caas-team/caas-project-monitoring/main/logo.png
 keywords:
 - monitoring
 dependencies:
 - name: kube-prometheus-stack
-  version: "58.4.0"
+  version: "68.1.1"
   repository: "https://prometheus-community.github.io/helm-charts"
 - condition: rkeEtcd.enabled
   name: rkeEtcd

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
   catalog.cattle.io/display-name: CaaS Cluster Monitoring V3
 name: caas-cluster-monitoring
 description: A Helm chart for Rancher Cluster Monitoring V3
-version: "0.0.14"
+version: "1.0.0-rc0"
 appVersion: "68.1.1"
 icon: https://raw.githubusercontent.com/caas-team/caas-project-monitoring/main/logo.png
 keywords:

--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ The installation can be configured using the various parameters defined in the `
 | `kube-prometheus-stack.alertmanager.alertmanagerSpec.forceEnableClusterMode` | bool | `false` |  |
 | `kube-prometheus-stack.alertmanager.alertmanagerSpec.image.registry` | string | `"mtr.devops.telekom.de"` |  |
 | `kube-prometheus-stack.alertmanager.alertmanagerSpec.image.repository` | string | `"kubeprometheusstack/alertmanager"` |  |
-| `kube-prometheus-stack.alertmanager.alertmanagerSpec.image.tag` | string | `"v0.27.0"` |  |
 | `kube-prometheus-stack.alertmanager.alertmanagerSpec.listenLocal` | bool | `false` |  |
 | `kube-prometheus-stack.alertmanager.alertmanagerSpec.logFormat` | string | `"logfmt"` |  |
 | `kube-prometheus-stack.alertmanager.alertmanagerSpec.logLevel` | string | `"info"` |  |
@@ -223,7 +222,6 @@ The installation can be configured using the various parameters defined in the `
 | `kube-prometheus-stack.grafana.forceDeployDatasources` | bool | `true` |  |
 | `kube-prometheus-stack.grafana.fullnameOverride` | string | `"rancher-monitoring-grafana"` |  |
 | `kube-prometheus-stack.grafana.image.repository` | string | `"kubeprometheusstack/grafana"` |  |
-| `kube-prometheus-stack.grafana.image.tag` | string | `"10.4.1"` |  |
 | `kube-prometheus-stack.grafana.initChownData.enabled` | bool | `false` |  |
 | `kube-prometheus-stack.grafana.nameOverride` | string | `"rancher-monitoring-grafana"` |  |
 | `kube-prometheus-stack.grafana.namespaceOverride` | string | `""` |  |
@@ -264,7 +262,6 @@ The installation can be configured using the various parameters defined in the `
 | `kube-prometheus-stack.grafana.sidecar.datasources.labelValue` | string | `"1"` |  |
 | `kube-prometheus-stack.grafana.sidecar.datasources.searchNamespace` | string | `""` |  |
 | `kube-prometheus-stack.grafana.sidecar.image.repository` | string | `"kubeprometheusstack/k8s-sidecar"` |  |
-| `kube-prometheus-stack.grafana.sidecar.image.tag` | string | `"1.24.6"` |  |
 | `kube-prometheus-stack.grafana.sidecar.plugins.searchNamespace` | string | `""` |  |
 | `kube-prometheus-stack.grafana.sidecar.resources.limits.cpu` | string | `"100m"` |  |
 | `kube-prometheus-stack.grafana.sidecar.resources.limits.memory` | string | `"100Mi"` |  |
@@ -280,7 +277,6 @@ The installation can be configured using the various parameters defined in the `
 | `kube-prometheus-stack.kube-state-metrics.honorLabels` | bool | `true` |  |
 | `kube-prometheus-stack.kube-state-metrics.image.registry` | string | `"mtr.devops.telekom.de"` |  |
 | `kube-prometheus-stack.kube-state-metrics.image.repository` | string | `"kubeprometheusstack/kube-state-metrics"` |  |
-| `kube-prometheus-stack.kube-state-metrics.image.tag` | string | `"v2.10.0"` |  |
 | `kube-prometheus-stack.kube-state-metrics.prometheus.monitor.enabled` | bool | `true` |  |
 | `kube-prometheus-stack.kube-state-metrics.prometheus.monitor.honorLabels` | bool | `true` |  |
 | `kube-prometheus-stack.kube-state-metrics.rbac.create` | bool | `true` |  |
@@ -383,7 +379,6 @@ The installation can be configured using the various parameters defined in the `
 | `kube-prometheus-stack.prometheus.prometheusSpec.ignoreNamespaceSelectors` | bool | `false` |  |
 | `kube-prometheus-stack.prometheus.prometheusSpec.image.registry` | string | `"mtr.devops.telekom.de"` |  |
 | `kube-prometheus-stack.prometheus.prometheusSpec.image.repository` | string | `"kubeprometheusstack/prometheus"` |  |
-| `kube-prometheus-stack.prometheus.prometheusSpec.image.tag` | string | `"v2.51.2"` |  |
 | `kube-prometheus-stack.prometheus.prometheusSpec.listenLocal` | bool | `false` |  |
 | `kube-prometheus-stack.prometheus.prometheusSpec.logFormat` | string | `"logfmt"` |  |
 | `kube-prometheus-stack.prometheus.prometheusSpec.logLevel` | string | `"info"` |  |
@@ -456,7 +451,6 @@ The installation can be configured using the various parameters defined in the `
 | `kube-prometheus-stack.prometheusOperator.admissionWebhooks.patch.image.pullPolicy` | string | `"Always"` |  |
 | `kube-prometheus-stack.prometheusOperator.admissionWebhooks.patch.image.registry` | string | `"mtr.devops.telekom.de"` |  |
 | `kube-prometheus-stack.prometheusOperator.admissionWebhooks.patch.image.repository` | string | `"kubeprometheusstack/kube-webhook-certgen"` |  |
-| `kube-prometheus-stack.prometheusOperator.admissionWebhooks.patch.image.tag` | string | `"v20221220-controller-v1.5.1-58-g787ea74b6"` |  |
 | `kube-prometheus-stack.prometheusOperator.admissionWebhooks.patch.resources.limits.cpu` | string | `"300m"` |  |
 | `kube-prometheus-stack.prometheusOperator.admissionWebhooks.patch.resources.limits.memory` | string | `"400Mi"` |  |
 | `kube-prometheus-stack.prometheusOperator.admissionWebhooks.patch.resources.requests.cpu` | string | `"100m"` |  |
@@ -468,7 +462,6 @@ The installation can be configured using the various parameters defined in the `
 | `kube-prometheus-stack.prometheusOperator.image.pullPolicy` | string | `"Always"` |  |
 | `kube-prometheus-stack.prometheusOperator.image.registry` | string | `"mtr.devops.telekom.de"` |  |
 | `kube-prometheus-stack.prometheusOperator.image.repository` | string | `"kubeprometheusstack/prometheus-operator"` |  |
-| `kube-prometheus-stack.prometheusOperator.image.tag` | string | `"v0.68.0"` |  |
 | `kube-prometheus-stack.prometheusOperator.prometheusConfigReloader.image.registry` | string | `"mtr.devops.telekom.de"` |  |
 | `kube-prometheus-stack.prometheusOperator.prometheusConfigReloader.image.repository` | string | `"kubeprometheusstack/prometheus-config-reloader"` |  |
 | `kube-prometheus-stack.thanosRuler.enabled` | bool | `false` |  |

--- a/hack/chart.sh
+++ b/hack/chart.sh
@@ -10,7 +10,6 @@ rm -rf charts/kube-prometheus-stack/charts/crds/
 yq 'del(.dependencies[] | select(.name == "crds"))' -i charts/kube-prometheus-stack/Chart.yaml
 
 echo "Packaging new chart"
-helm dependency update
 helm package charts/kube-prometheus-stack -d charts
 
 echo "Packaging caas-cluster-monitoring"

--- a/templates/np-dynakube.yaml
+++ b/templates/np-dynakube.yaml
@@ -13,7 +13,7 @@ spec:
             field.cattle.io/projectId: dynatrace
   podSelector:
     matchLabels:
-      release: rancher-monitoring
+      release: {{ .Release.Name }}
   policyTypes:
     - Ingress
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -47,7 +47,6 @@ global:
   cattle:
     clusterId: local
     clusterName: local
-    # projectId: &projectId p-xxxxx
     systemDefaultRegistry: "mtr.devops.telekom.de"
   imageRegistry: mtr.devops.telekom.de
 

--- a/values.yaml
+++ b/values.yaml
@@ -74,7 +74,6 @@ kube-prometheus-stack:
       image:
         registry: mtr.devops.telekom.de
         repository: kubeprometheusstack/alertmanager
-        tag: v0.27.0
       listenLocal: false
       logFormat: logfmt
       logLevel: info
@@ -295,7 +294,6 @@ kube-prometheus-stack:
         auto_assign_org_role: Viewer
     image:
       repository: kubeprometheusstack/grafana
-      tag: 10.4.1
     initChownData:
       enabled: false
     nameOverride: rancher-monitoring-grafana
@@ -356,7 +354,6 @@ kube-prometheus-stack:
         searchNamespace: ""
       image:
         repository: kubeprometheusstack/k8s-sidecar
-        tag: 1.24.6
       plugins:
         searchNamespace: ""
       resources:
@@ -382,7 +379,6 @@ kube-prometheus-stack:
     image:
       registry: mtr.devops.telekom.de
       repository: kubeprometheusstack/kube-state-metrics
-      tag: v2.10.0
     prometheus:
       monitor:
         enabled: true
@@ -522,7 +518,6 @@ kube-prometheus-stack:
       image:
         registry: mtr.devops.telekom.de
         repository: kubeprometheusstack/prometheus
-        tag: v2.51.2
       listenLocal: false
       logFormat: logfmt
       logLevel: info
@@ -660,7 +655,6 @@ kube-prometheus-stack:
           pullPolicy: Always
           registry: mtr.devops.telekom.de
           repository: kubeprometheusstack/kube-webhook-certgen
-          tag: v20221220-controller-v1.5.1-58-g787ea74b6
         resources:
           limits:
             cpu: 300m
@@ -678,7 +672,6 @@ kube-prometheus-stack:
       pullPolicy: Always
       registry: mtr.devops.telekom.de
       repository: kubeprometheusstack/prometheus-operator
-      tag: v0.68.0
     prometheusConfigReloader:
       image:
         registry: mtr.devops.telekom.de


### PR DESCRIPTION
## Motivation

Resolves #30 and #31 

## Changes

- Bumped the kube-prometheus-stack to 68.1.1
- Removed unused values
- Cleanup on the hack script

## Tests done

Tested in a CaaS development cluster. After updating, all components are still running as before, new grafana dashboards appeared and old dashboards aren't deprecated anymore.

