### PR TITLE
Updated the comp matrix for the 1.0.0 roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following table shows the compatibility between the CaaS Cluster Monitoring 
 | ----------------------- | --------------------------------------- | ------------------------------ |
 | < 0.0.6                 | < 1.0.0                                 | 51.0.3                         |
 | 0.0.6 < x < 1.0.0       | 1.0.0 <= y < 1.4.0                      | 58.4.0                         |
+| 1.0.0                   | 1.4.0 <= y < 1.5.0                      | 68.1.1                         |
 
 where `x` is the CaaS Cluster Monitoring Version and `y` is the CaaS Project Monitoring Version.
 

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -30,6 +30,7 @@ The following table shows the compatibility between the CaaS Cluster Monitoring 
 | ----------------------- | --------------------------------------- | ------------------------------ |
 | < 0.0.6                 | < 1.0.0                                 | 51.0.3                         |
 | 0.0.6 < x < 1.0.0       | 1.0.0 <= y < 1.4.0                      | 58.4.0                         |
+| 1.0.0                   | 1.4.0 <= y < 1.5.0                      | 68.1.1                         |
 
 where `x` is the CaaS Cluster Monitoring Version and `y` is the CaaS Project Monitoring Version.
 


### PR DESCRIPTION
## Motivation

After the 1.0.0 release we aim to keep up the CRDs of the prometheus operator and update them in tandem with the chart used in project-monitoring.

We should signalize our intent with our users by updating the compatibility matrix.

## Changes

Just the matrix.