### PR TITLE
Feat/webhook netpol

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,16 +2,17 @@ name: Helm Lint
 
 on:
   push:
-    
+
+
 jobs:
   helm:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-      - name: Helm lint
-        run: |
-          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-          helm version
-          helm lint .
-
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+    - name: Helm lint
+      run: |
+        curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+        helm version
+        helm dependency update
+        helm lint .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/norwoodj/helm-docs
-    rev: "v1.11.3"
+    rev: "v1.14.2"
     hooks:
       - id: helm-docs
         args:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
   catalog.cattle.io/display-name: CaaS Cluster Monitoring V3
 name: caas-cluster-monitoring
 description: A Helm chart for Rancher Cluster Monitoring V3
-version: "1.0.1-rc0"
+version: "1.0.1-rc1"
 appVersion: "68.1.1"
 icon: https://raw.githubusercontent.com/caas-team/caas-project-monitoring/main/logo.png
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
   catalog.cattle.io/display-name: CaaS Cluster Monitoring V3
 name: caas-cluster-monitoring
 description: A Helm chart for Rancher Cluster Monitoring V3
-version: "1.0.0"
+version: "1.0.1-rc0"
 appVersion: "68.1.1"
 icon: https://raw.githubusercontent.com/caas-team/caas-project-monitoring/main/logo.png
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
   catalog.cattle.io/display-name: CaaS Cluster Monitoring V3
 name: caas-cluster-monitoring
 description: A Helm chart for Rancher Cluster Monitoring V3
-version: "1.0.1-rc1"
+version: "1.0.1"
 appVersion: "68.1.1"
 icon: https://raw.githubusercontent.com/caas-team/caas-project-monitoring/main/logo.png
 keywords:

--- a/templates/np-webhook.yaml
+++ b/templates/np-webhook.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.caas.clusterCosts }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-webhook-ingress
+  namespace: cattle-monitoring-system
+spec:
+  ingress:
+    - ports:
+        - port: 443
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: prometheus-operator
+      app: {{ .Release.Name }}-operator
+  policyTypes:
+    - Ingress
+{{- end }}

--- a/templates/np-webhook.yaml
+++ b/templates/np-webhook.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.caas.clusterCosts }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -16,4 +15,3 @@ spec:
       app: {{ .Release.Name }}-operator
   policyTypes:
     - Ingress
-{{- end }}

--- a/templates/np-webhook.yaml
+++ b/templates/np-webhook.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   ingress:
     - ports:
-        - port: 443
+        - port: {{ index .Values "kube-prometheus-stack" "prometheusOperator" "tls" "internalPort" }}
           protocol: TCP
   podSelector:
     matchLabels:


### PR DESCRIPTION
## Motivation

The network policy should be activated per default always, to only allow ingress to the operator's webhook (no other interaction seems to be needed, as we don't have other ports exposed on the operator).

Since no network policy exists for the operator and other ingress policies are present in the namespace, any communication with the webhook of the operator results in a timeout, which has multiple side-effects for the cluster's health.

## Changes

Added an ingress netpol for the operator's webhook port (the one port that's exposed). Since we don't use a NodePort, no extra consideration was given to that port.

## Tests done

Tested in rke2 cluster; no validation errors appear to happen anymore when trying to reach the rancher webhook.