### PR TITLE
Feat/OIDC prom auth

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
   catalog.cattle.io/display-name: CaaS Cluster Monitoring V3
 name: caas-cluster-monitoring
 description: A Helm chart for Rancher Cluster Monitoring V3
-version: "1.0.1-oidchotfix"
+version: "1.0.1"
 appVersion: "68.1.1"
 icon: https://raw.githubusercontent.com/caas-team/caas-project-monitoring/main/logo.png
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
   catalog.cattle.io/display-name: CaaS Cluster Monitoring V3
 name: caas-cluster-monitoring
 description: A Helm chart for Rancher Cluster Monitoring V3
-version: "1.0.1"
+version: "1.0.1-oidchotfix"
 appVersion: "68.1.1"
 icon: https://raw.githubusercontent.com/caas-team/caas-project-monitoring/main/logo.png
 keywords:

--- a/README.md
+++ b/README.md
@@ -357,7 +357,9 @@ The installation can be configured using the various parameters defined in the `
 | `kube-prometheus-stack.prometheus.prometheusSpec.containers[0].command[0]` | string | `"prometheus-auth"` |  |
 | `kube-prometheus-stack.prometheus.prometheusSpec.containers[0].env[0].name` | string | `"POD_IP"` |  |
 | `kube-prometheus-stack.prometheus.prometheusSpec.containers[0].env[0].valueFrom.fieldRef.fieldPath` | string | `"status.podIP"` |  |
-| `kube-prometheus-stack.prometheus.prometheusSpec.containers[0].image` | string | `"mtr.devops.telekom.de/caas/prometheus-auth:0.6.0"` |  |
+| `kube-prometheus-stack.prometheus.prometheusSpec.containers[0].env[1].name` | string | `"CLUSTER_NAME"` |  |
+| `kube-prometheus-stack.prometheus.prometheusSpec.containers[0].env[1].value` | string | `"local"` |  |
+| `kube-prometheus-stack.prometheus.prometheusSpec.containers[0].image` | string | `"mtr.devops.telekom.de/caas/prometheus-auth:0.7.1"` |  |
 | `kube-prometheus-stack.prometheus.prometheusSpec.containers[0].name` | string | `"prometheus-agent"` |  |
 | `kube-prometheus-stack.prometheus.prometheusSpec.containers[0].ports[0].containerPort` | int | `9091` |  |
 | `kube-prometheus-stack.prometheus.prometheusSpec.containers[0].ports[0].name` | string | `"http-auth"` |  |

--- a/values.yaml
+++ b/values.yaml
@@ -492,7 +492,10 @@ kube-prometheus-stack:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: mtr.devops.telekom.de/caas/prometheus-auth:0.6.0
+        - name: CLUSTER_NAME
+          # replace with name of the cluster, if you want OIDC authentication to work
+          value: local 
+        image: mtr.devops.telekom.de/caas/prometheus-auth:0.7.1
         name: prometheus-agent
         ports:
         - containerPort: 9091


### PR DESCRIPTION
## Motivation

Hotfix to make cluster monitoring work again after OIDC rollout.

## Changes

Just added the new prometheus auth version as the default version. The downstream clusters will have to define the cluster name for the time being.

## Tests done

A test on a cluster was done to assert this change will work