### PR TITLE
Fix/kubelet netpols

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 0.2.1
 - name: hardenedKubelet
   repository: file://./charts/hardenedKubelet
-  version: 0.2.1
+  version: 0.2.2
 - name: rke2ControllerManager
   repository: file://./charts/rke2ControllerManager
   version: 0.1.7
@@ -35,5 +35,5 @@ dependencies:
 - name: rke2Scheduler
   repository: file://./charts/rke2Scheduler
   version: 0.1.7
-digest: sha256:46cb908ea4fbd81d485cd7871f0fe694f7b9d16438838d29b68f081fd0a18105
-generated: "2025-06-23T08:56:29.07300368+02:00"
+digest: sha256:439f105ecb3792e48a99d976e50a21384c555d984f81458190bd8eec4858cfdb
+generated: "2025-07-18T10:45:56.23925451+02:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
   catalog.cattle.io/display-name: CaaS Cluster Monitoring V3
 name: caas-cluster-monitoring
 description: A Helm chart for Rancher Cluster Monitoring V3
-version: "1.0.4"
+version: "1.0.5-rc0"
 appVersion: "68.1.1"
 icon: https://raw.githubusercontent.com/caas-team/caas-project-monitoring/main/logo.png
 keywords:
@@ -35,7 +35,7 @@ dependencies:
 - condition: hardenedKubelet.enabled
   name: hardenedKubelet
   repository: file://./charts/hardenedKubelet
-  version: 0.2.1
+  version: 0.2.2
 - condition: rke2ControllerManager.enabled
   name: rke2ControllerManager
   repository: file://./charts/rke2ControllerManager

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
   catalog.cattle.io/display-name: CaaS Cluster Monitoring V3
 name: caas-cluster-monitoring
 description: A Helm chart for Rancher Cluster Monitoring V3
-version: "1.0.5-rc0"
+version: "1.0.5"
 appVersion: "68.1.1"
 icon: https://raw.githubusercontent.com/caas-team/caas-project-monitoring/main/logo.png
 keywords:

--- a/charts/hardenedKubelet/Chart.yaml
+++ b/charts/hardenedKubelet/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.1.0
 description: Sets up a deployment of the PushProx proxy and a DaemonSet of PushProx clients.
 name: hardenedKubelet
 type: application
-version: 0.2.1
+version: 0.2.2

--- a/charts/hardenedKubelet/README.md
+++ b/charts/hardenedKubelet/README.md
@@ -1,6 +1,6 @@
 # hardenedKubelet
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Sets up a deployment of the PushProx proxy and a DaemonSet of PushProx clients.
 
@@ -48,6 +48,7 @@ Sets up a deployment of the PushProx proxy and a DaemonSet of PushProx clients.
 | kubeVersionOverrides | list | `[]` |  |
 | metricsPort | int | `2739` |  |
 | namespaceOverride | string | `""` |  |
+| networkPolicy.enabled | bool | `true` |  |
 | proxy.command[0] | string | `"pushprox-proxy"` |  |
 | proxy.enabled | bool | `true` |  |
 | proxy.image.repository | string | `"rancher/pushprox-proxy"` |  |

--- a/charts/hardenedKubelet/templates/pushprox-networkpolicy.yaml
+++ b/charts/hardenedKubelet/templates/pushprox-networkpolicy.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "pushProxy.proxy.name" . }}-ingress
+  namespace: {{ template "pushprox.namespace" . }}
+spec:
+  ingress:
+  - ports:
+    - port: {{ .Values.proxy.port }}
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      {{ include "pushProxy.proxy.labels" . | nindent 6 }}
+  policyTypes:
+  - Ingress
+{{- end }}

--- a/charts/hardenedKubelet/values.yaml
+++ b/charts/hardenedKubelet/values.yaml
@@ -164,3 +164,7 @@ proxy:
     repository: rancher/pushprox-proxy
     tag: v0.1.3-rancher2-proxy
   command: ["pushprox-proxy"]
+
+networkPolicy:
+  # If set to true, a NetworkPolicy will be created that allows ingress traffic to the proxy
+  enabled: true


### PR DESCRIPTION
## Motivation

Implementing the network policies for all pushprox pods to actually allow ingress to them was done in https://github.com/caas-team/caas-cluster-monitoring/pull/42. 

Unfortunately, I forgot to add the same network policies to the kubelet pods. Because they were missing, only one pod could scrape the kubelet metrics (the one client that resided in the same node as the proxy itself).

## Changes

This just adds the missing network policy for the kubelet pushprox.

## Tests done

Tested in an rke2 staging cluster - all kubelet pods are now scraped successfully:

<img width="2542" height="756" alt="image" src="https://github.com/user-attachments/assets/c9d54bbe-bb0a-4fc9-aa2f-3c0231ba9f62" />
