### PR TITLE
Minimize nginx metrics

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
   catalog.cattle.io/display-name: CaaS Cluster Monitoring V3
 name: caas-cluster-monitoring
 description: A Helm chart for Rancher Cluster Monitoring V3
-version: "1.0.5"
+version: "1.0.6-rc0"
 appVersion: "68.1.1"
 icon: https://raw.githubusercontent.com/caas-team/caas-project-monitoring/main/logo.png
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
   catalog.cattle.io/display-name: CaaS Cluster Monitoring V3
 name: caas-cluster-monitoring
 description: A Helm chart for Rancher Cluster Monitoring V3
-version: "1.0.6-rc0"
+version: "1.0.6"
 appVersion: "68.1.1"
 icon: https://raw.githubusercontent.com/caas-team/caas-project-monitoring/main/logo.png
 keywords:

--- a/values.yaml
+++ b/values.yaml
@@ -953,6 +953,18 @@ rke2IngressNginx:
   component: ingress-nginx
   networkPolicy:
     enabled: false
+  serviceMonitor:
+    endpoints:
+    - port: metrics
+      honorLabels: true
+      # -- Relabeling to keep only the needed metrics
+      # -- for the grafana dashboards. If additional metrics
+      # -- are needed, they should be added to this regex.
+      metricRelabelings:
+      - action: keep
+        regex: "nginx_ingress_controller_(config_last_reload_successful(?:_timestamp_seconds)?|nginx_process_(connections|cpu_seconds_total|resident_memory_bytes)|request_size_sum|request_duration_seconds_(count|bucket)|requests|response_size_(sum|count|bucket)|response_duration_seconds_(bucket|sum)|ssl_expire_time_seconds|success|orphan_ingress)"
+        sourceLabels:
+        - __name__
   # in the RKE2 cluster, the ingress-nginx-controller is deployed
   # as a non-hostNetwork workload starting at the following versions
   # - >= v1.22.12+rke2r1 < 1.23.0-0


### PR DESCRIPTION
## Motivation

We should only collect the metrics we actually need to ensure stable operations of the central prometheus.

## Changes

Added a servicemonitor configuration to only keep the required metrics.

## Tests done

Runs like this in all staging clusters. The 1.0.6-rc0 was additionally deployed in our s4 environment to test the new tag.